### PR TITLE
Fix sslCert path in Angular serve options

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -66,7 +66,7 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "sslKey": "./ssl/server.key",
-            "sslCert": ".//ssl/server.crt",
+            "sslCert": "./ssl/server.crt",
             "ssl": true
           },
           "configurations": {


### PR DESCRIPTION
## Summary
- fix a typo in `client/angular.json` where `sslCert` path had an extra slash

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6882460ff67483309d3891e9ead5a211